### PR TITLE
Simple Test for Android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,4 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.quipper.exam.test" >
+    package="com.quipper.exam.test">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/quipper/exam/test/ImageAdapter.java
+++ b/app/src/main/java/com/quipper/exam/test/ImageAdapter.java
@@ -1,0 +1,93 @@
+package com.quipper.exam.test;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.support.v4.view.PagerAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.Toast;
+
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.assist.FailReason;
+import com.nostra13.universalimageloader.core.assist.ImageScaleType;
+import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
+import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * Created by marlon1300 on 5/28/2015.
+ */
+public class ImageAdapter extends PagerAdapter {
+    private LayoutInflater inflater;
+    private DisplayImageOptions options;
+    private String[] images = new String[]{};
+    MainActivityFragment.Callback callback;
+    private static final SimpleDateFormat IMAGE_TIME_FORMAT = new SimpleDateFormat("yyyyMMddHH", Locale.US);
+
+    ImageAdapter(Context context) {
+        Date dateToShow = new Date(new Date().getTime() - 30 * 60 * 1000);
+        String url = String.format("http://www.jma.go.jp/jp/gms/imgs/5/infrared/1/%s00-00.png",
+                IMAGE_TIME_FORMAT.format(dateToShow));
+        images = new String[]{url};
+        inflater = LayoutInflater.from(context);
+        callback = (MainActivityFragment.Callback) context;
+        options = new DisplayImageOptions.Builder()
+                .showImageForEmptyUri(android.R.drawable.stat_notify_error)
+                .showImageOnFail(android.R.drawable.stat_notify_error)
+                .resetViewBeforeLoading(true)
+                .cacheOnDisk(true)
+                .imageScaleType(ImageScaleType.EXACTLY)
+                .bitmapConfig(Bitmap.Config.RGB_565)
+                .considerExifParams(true)
+                .displayer(new FadeInBitmapDisplayer(300))
+                .build();
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup view, int position) {
+        View imageLayout = inflater.inflate(R.layout.view_pager_item, view, false);
+        ImageView imageView = (ImageView) imageLayout.findViewById(R.id.view_pager_item_image);
+        final ProgressBar spinner = (ProgressBar) imageLayout.findViewById(R.id.loading);
+        ImageLoader.getInstance().displayImage(images[position], imageView, options, new SimpleImageLoadingListener() {
+            @Override
+            public void onLoadingStarted(String imageUri, View view) {
+                spinner.setVisibility(View.VISIBLE);
+            }
+
+            @Override
+            public void onLoadingFailed(String imageUri, View view, FailReason failReason) {
+                Toast.makeText(view.getContext(), failReason.getCause().getMessage(), Toast.LENGTH_SHORT).show();
+                spinner.setVisibility(View.GONE);
+            }
+
+            @Override
+            public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
+                spinner.setVisibility(View.GONE);
+            }
+        });
+        view.addView(imageLayout, 0);
+        return imageLayout;
+    }
+
+    @Override
+    public int getCount() {
+        return images.length;
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        container.removeView((View) object);
+    }
+
+    @Override
+    public boolean isViewFromObject(View view, Object object) {
+        return view.equals(object);
+    }
+}

--- a/app/src/main/java/com/quipper/exam/test/ImageFragment.java
+++ b/app/src/main/java/com/quipper/exam/test/ImageFragment.java
@@ -1,0 +1,27 @@
+package com.quipper.exam.test;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Created by marlon1300 on 5/28/2015.
+ */
+public class ImageFragment extends Fragment {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_view_pager_container, container, false);
+        ViewPager pager = (ViewPager) rootView.findViewById(R.id.view_pager);
+        pager.setAdapter(new ImageAdapter(getActivity()));
+        pager.setCurrentItem(0);
+        return rootView;
+    }
+}

--- a/app/src/main/java/com/quipper/exam/test/MainActivity.java
+++ b/app/src/main/java/com/quipper/exam/test/MainActivity.java
@@ -1,5 +1,6 @@
 package com.quipper.exam.test;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
@@ -7,6 +8,11 @@ import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+
+import com.nostra13.universalimageloader.cache.disc.naming.Md5FileNameGenerator;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+import com.nostra13.universalimageloader.core.assist.QueueProcessingType;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -21,7 +27,7 @@ import java.util.TimeZone;
 
 public class MainActivity extends ActionBarActivity implements MainActivityFragment.Callback {
     private MainActivityFragment fragment;
-    private LoadTask loadTask;
+//    private LoadTask loadTask;
 
     private static final SimpleDateFormat IMAGE_TIME_FORMAT = new SimpleDateFormat("yyyyMMddHH", Locale.US);
     private static final SimpleDateFormat LABEL_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:00", Locale.US);
@@ -34,11 +40,21 @@ public class MainActivity extends ActionBarActivity implements MainActivityFragm
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
+        initImageLoader(getApplicationContext());
         fragment = (MainActivityFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-        fragment.setRetainInstance(false);
+        fragment.setRetainInstance(true);
     }
+    public static void initImageLoader(Context context) {
+        ImageLoaderConfiguration.Builder config = new ImageLoaderConfiguration.Builder(context);
+        config.threadPriority(Thread.NORM_PRIORITY - 2);
+        config.denyCacheImageMultipleSizesInMemory();
+        config.diskCacheFileNameGenerator(new Md5FileNameGenerator());
+        config.diskCacheSize(50 * 1024 * 1024); // 50 MiB
+        config.tasksProcessingOrder(QueueProcessingType.LIFO);
+        config.writeDebugLogs();
 
+        ImageLoader.getInstance().init(config.build());
+    }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -64,61 +80,66 @@ public class MainActivity extends ActionBarActivity implements MainActivityFragm
 
     @Override
     public void load() {
-        URL imageUrl;
+//        URL imageUrl;
         Date dateToShow = new Date(new Date().getTime() - 30 * 60 * 1000);
-        String url = String.format("http://www.jma.go.jp/jp/gms/imgs/5/infrared/1/%s00-00.png",
-                IMAGE_TIME_FORMAT.format(dateToShow));
-        try {
-            imageUrl = new URL(url);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return;
-        }
-
-        if (loadTask != null &&
-                loadTask.getStatus() == AsyncTask.Status.RUNNING &&
-                !loadTask.isCancelled()) {
-            return;
-        }
-        loadTask = new LoadTask(fragment);
-        loadTask.execute(imageUrl);
-        fragment.setDateLabel(LABEL_FORMAT.format(dateToShow));
+//        String url = String.format("http://www.jma.go.jp/jp/gms/imgs/5/infrared/1/%s00-00.png",
+//                IMAGE_TIME_FORMAT.format(dateToShow));
+//        try {
+//            imageUrl = new URL(url);
+//        } catch (MalformedURLException e) {
+//            e.printStackTrace();
+//            return;
+//        }
+//
+//        if (loadTask != null &&
+//                loadTask.getStatus() == AsyncTask.Status.RUNNING &&
+//                !loadTask.isCancelled()) {
+//            return;
+//        }
+//        loadTask = new LoadTask(fragment);
+//        loadTask.execute(imageUrl);
+//        fragment.setDateLabel(LABEL_FORMAT.format(dateToShow));
     }
 
-    static class LoadTask extends AsyncTask<URL, Void, List<Bitmap>> {
-        private MainActivityFragment fragment;
-
-        LoadTask(MainActivityFragment fragment) {
-            this.fragment = fragment;
-        }
-
-        @Override
-        protected List<Bitmap> doInBackground(URL... params) {
-            List<Bitmap> results = new ArrayList<>();
-            try {
-                for (URL url : params) {
-                    if (isCancelled()) {
-                        break;
-                    }
-                    URLConnection connection = url.openConnection();
-                    Bitmap bitmap = BitmapFactory.decodeStream(connection.getInputStream());
-                    if (bitmap != null) {
-                        results.add(bitmap);
-                    }
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            return results;
-        }
-
-        @Override
-        protected void onPostExecute(List<Bitmap> bitmaps) {
-            super.onPostExecute(bitmaps);
-
-            if (!bitmaps.isEmpty()) {
-                fragment.showImage(bitmaps.get(0));
-            }
-        }
+    @Override
+    public ImageLoader getImageLoader() {
+        return ImageLoader.getInstance();
     }
+
+//    static class LoadTask extends AsyncTask<URL, Void, List<Bitmap>> {
+//        private MainActivityFragment fragment;
+//
+//        LoadTask(MainActivityFragment fragment) {
+//            this.fragment = fragment;
+//        }
+//
+//        @Override
+//        protected List<Bitmap> doInBackground(URL... params) {
+//            List<Bitmap> results = new ArrayList<>();
+//            try {
+//                for (URL url : params) {
+//                    if (isCancelled()) {
+//                        break;
+//                    }
+//                    URLConnection connection = url.openConnection();
+//                    Bitmap bitmap = BitmapFactory.decodeStream(connection.getInputStream());
+//                    if (bitmap != null) {
+//                        results.add(bitmap);
+//                    }
+//                }
+//            } catch (IOException e) {
+//                e.printStackTrace();
+//            }
+//            return results;
+//        }
+//
+//        @Override
+//        protected void onPostExecute(List<Bitmap> bitmaps) {
+//            super.onPostExecute(bitmaps);
+//
+//            if (!bitmaps.isEmpty()) {
+//                fragment.showImage(bitmaps.get(0));
+//            }
+//        }
+//    }
 }

--- a/app/src/main/java/com/quipper/exam/test/MainActivityFragment.java
+++ b/app/src/main/java/com/quipper/exam/test/MainActivityFragment.java
@@ -4,12 +4,26 @@ import android.app.Activity;
 import android.graphics.Bitmap;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.assist.FailReason;
+import com.nostra13.universalimageloader.core.assist.ImageScaleType;
+import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
+import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * A placeholder fragment containing a simple view.
@@ -17,12 +31,22 @@ import android.widget.TextView;
 public class MainActivityFragment extends Fragment {
     public interface Callback {
         void load();
+        ImageLoader getImageLoader();
+    }
+
+    private static final SimpleDateFormat IMAGE_TIME_FORMAT = new SimpleDateFormat("yyyyMMddHH", Locale.US);
+    private static final SimpleDateFormat LABEL_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:00", Locale.US);
+    Date dateToShow = new Date(new Date().getTime() - 30 * 60 * 1000);
+    static {
+        TimeZone jst = TimeZone.getTimeZone("GMT+09:00");
+        IMAGE_TIME_FORMAT.setTimeZone(jst);
     }
 
     private Button loadButton;
     private ImageView earthImage;
     private TextView dateText;
     private Callback callback;
+    private DisplayImageOptions options;
 
     public MainActivityFragment() {
     }
@@ -32,17 +56,17 @@ public class MainActivityFragment extends Fragment {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_main, container, false);
         loadButton = (Button) view.findViewById(R.id.load_button);
-        earthImage = (ImageView) view.findViewById(R.id.earth_image);
+//        earthImage = (ImageView) view.findViewById(R.id.earth_image);
         dateText = (TextView) view.findViewById(R.id.date_text);
-
-        loadButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (callback != null) {
-                    callback.load();
-                }
-            }
-        });
+        setDateLabel(LABEL_FORMAT.format(dateToShow));
+//        loadButton.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View v) {
+//        if (callback != null) {
+//            callback.load();
+//        }
+//            }
+//        });
 
         return view;
     }
@@ -64,9 +88,9 @@ public class MainActivityFragment extends Fragment {
         loadButton = null;
     }
 
-    public void showImage(Bitmap bitmap) {
-        earthImage.setImageBitmap(bitmap);
-    }
+//    public void showImage(Bitmap bitmap) {
+//        earthImage.setImageBitmap(bitmap);
+//    }
 
     public void setDateLabel(CharSequence dateLabel) {
         dateText.setText(dateLabel);

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,24 +1,31 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivityFragment">
+    tools:context=".MainActivityFragment">
 
-    <Button android:id="@+id/load_button"
+    <Button
+        android:id="@+id/load_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Load"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:visibility="gone" />
 
-    <TextView android:id="@+id/date_text"
-        android:layout_toRightOf="@+id/load_button"
-        android:layout_alignParentRight="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+    <TextView
+        android:id="@+id/date_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:gravity="center" />
 
-    <ImageView android:id="@+id/earth_image"
+    <fragment
+        android:name="com.quipper.exam.test.ImageFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/load_button"/>
+        android:layout_below="@id/date_text" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_view_pager_container.xml
+++ b/app/src/main/res/layout/fragment_view_pager_container.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/view_pager"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent" />

--- a/app/src/main/res/layout/view_pager_item.xml
+++ b/app/src/main/res/layout/view_pager_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:padding="1dip">
+
+	<ImageView
+		android:id="@+id/view_pager_item_image"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center"
+		android:adjustViewBounds="true"
+		 />
+
+	<ProgressBar
+		android:id="@+id/loading"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center"
+		android:visibility="gone" />
+
+</FrameLayout>


### PR DESCRIPTION
- Add INTERNET permission to fix app crash when fetching image
- Use Android Universal Image Loader library for loading, caching and displaying images when changing orientation and switching between other apps
- Remove load button for better user experience
- Commented unused codes